### PR TITLE
Fixed i161/i150

### DIFF
--- a/src/Language/Clafer/Intermediate/ResolverInheritance.hs
+++ b/src/Language/Clafer/Intermediate/ResolverInheritance.hs
@@ -151,11 +151,10 @@ analyzeCard :: SEnv -> IClafer -> Maybe Interval
 analyzeCard env clafer = card clafer `mplus` Just card'
   where
   card'
-    | isAbstract clafer                          = (0, -1)
-    | (isJust $ context env) && isKeyword pGcard = (0, 1)
-    | otherwise                                  = (1, 1)
-  pGcard = fromJust $ gcard $ fromJust $ context env
-
+    | isAbstract clafer = (0, -1)
+    | (isJust $ context env) && pGcard == (0, -1) = (1, 1) 
+    | otherwise = (0, 1)
+  pGcard = interval $ fromJust $ gcard $ fromJust $ context env
 
 analyzeElement :: SEnv -> IElement -> IElement
 analyzeElement env x = case x of


### PR DESCRIPTION
Changed rule:
if group cardinality is 0.._, all children have default card of 1.1
if group cardinality is not 0.._ all children have default card of 0..1

see [i150](http://gsd.uwaterloo.ca:8888/question/682/or-group-keyword-has-different-semantics-than)
see [i61](http://gsd.uwaterloo.ca:8888/question/254/children-of-all-groups-other-than-default-should)
